### PR TITLE
Add CUDA setup to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,17 @@
+name: Build
+
+on: [push, workflow_dispatch]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install CUDA and dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y ocl-icd-opencl-dev nvidia-cuda-toolkit
+        echo "/usr/local/cuda/bin" >> $GITHUB_PATH
+    - name: make all
+      run: make all


### PR DESCRIPTION
## Summary
- Add Build workflow that installs CUDA toolkit and OpenCL dependencies
- Add CUDA bin directory to PATH so nvcc can be used
- Build the project with `make all`

## Testing
- `make all`


------
https://chatgpt.com/codex/tasks/task_e_68965abefe08832facb5046da4ac4d31